### PR TITLE
Fix class attribute post update handler so it properly works with constant variable combinations

### DIFF
--- a/plugins/compile_client_app/front_end/helpers/post_update_handlers.js
+++ b/plugins/compile_client_app/front_end/helpers/post_update_handlers.js
@@ -170,7 +170,6 @@ module.exports = function (register_global_helper) {
           updated_class_value += scope.state[attribute_input_symbol] || '';
         }
 
-        var current_value = $$HELPERS.convert_to_attribute_value$$(value);
         var value_classes = updated_class_value.split(' ').filter(function (classValue) {
           return !!classValue;
         });

--- a/plugins/compile_client_app/front_end/helpers/post_update_handlers.js
+++ b/plugins/compile_client_app/front_end/helpers/post_update_handlers.js
@@ -167,7 +167,7 @@ module.exports = function (register_global_helper) {
         var i;
         for (i = 1; i < symbols.length; ++i) {
           var attribute_input_symbol = symbols[i];
-          updated_class_value += scope.state[attribute_input_symbol] || '';
+          updated_class_value += $$HELPERS.convert_to_attribute_value$$(scope.state[attribute_input_symbol]);
         }
 
         var value_classes = updated_class_value.split(' ').filter(function (classValue) {

--- a/plugins/compile_client_app/front_end/helpers/post_update_handlers.js
+++ b/plugins/compile_client_app/front_end/helpers/post_update_handlers.js
@@ -155,21 +155,28 @@ module.exports = function (register_global_helper) {
 
   register_global_helper(
     'generate_dom_element_class_post_update_handler',
-    function (initial_attribute_input_value) {
-      var last_value_classes = initial_attribute_input_value.split(' ').filter(function (classValue) {
+    function (initial_attribute_value) {
+      var last_value_classes = initial_attribute_value.split(' ').filter(function (classValue) {
         return !!classValue;
       });
 
-      return function (value, scope, dom_element_symbol) {
+      return function (value, scope, symbols) {
+        var dom_element = scope.state[symbols[0]];
+
+        var updated_class_value = '';
+        var i;
+        for (i = 1; i < symbols.length; ++i) {
+          var attribute_input_symbol = symbols[i];
+          updated_class_value += scope.state[attribute_input_symbol] || '';
+        }
+
         var current_value = $$HELPERS.convert_to_attribute_value$$(value);
-        var value_classes = current_value.split(' ').filter(function (classValue) {
+        var value_classes = updated_class_value.split(' ').filter(function (classValue) {
           return !!classValue;
         });
 
-        var dom_element = scope.state[dom_element_symbol];
         var current_classes = dom_element.className.split(' ');
         var updated_classes;
-        var i;
 
         if (last_value_classes.length) {
           updated_classes = [];

--- a/plugins/compile_client_app/front_end/helpers/scope_methods.js
+++ b/plugins/compile_client_app/front_end/helpers/scope_methods.js
@@ -248,21 +248,27 @@ module.exports = function (register_scope_method) {
         var attribute_input_value;
         var attribute_input_symbols = attribute_symbols.slice(1);
         var single_attribute_variable = attribute_input_symbols.length === 1;
+        var j;
+        var attribute_symbol;
 
-        for (var j = 0; j < attribute_input_symbols.length; ++j) {
-          var attribute_symbol = attribute_input_symbols[j];
+        for (j = 0; j < attribute_input_symbols.length; ++j) {
+          attribute_symbol = attribute_input_symbols[j];
 
-          var symbol_metadata = scope_context['$$SCOPE_METHODS.get_scope_symbol_metadata$$'](attribute_symbol);
           attribute_input_value = scope_context.state[attribute_symbol];
           var attribute_converted_input_value = $$HELPERS.convert_to_attribute_value$$(attribute_input_value);
           if (attribute_converted_input_value) {
             attribute_value += attribute_converted_input_value;
           }
+        }
+
+        for (j = 0; j < attribute_input_symbols.length; ++j) {
+          attribute_symbol = attribute_input_symbols[j];
+          var symbol_metadata = scope_context['$$SCOPE_METHODS.get_scope_symbol_metadata$$'](attribute_symbol);
 
           if (attribute_name === 'class') {
             symbol_metadata.add_post_update_handler(
-              $$HELPERS.generate_dom_element_class_post_update_handler$$(attribute_converted_input_value),
-              assign_to_symbol
+              $$HELPERS.generate_dom_element_class_post_update_handler$$(attribute_value),
+              assign_to_symbol+attribute_input_symbols
             );
           } else if (attribute_name === 'style') {
             symbol_metadata.add_post_update_handler(


### PR DESCRIPTION
Preserve existing behavior that handles class additions outside of the framework, but make sure cases like thing-{{thingType}} work when used in the class attribute.